### PR TITLE
Fix possible data loss after power failure when epoch is 0xff.

### DIFF
--- a/dhara/journal.c
+++ b/dhara/journal.c
@@ -352,6 +352,7 @@ static int find_root(struct dhara_journal *j, dhara_page_t start,
 		if (!dhara_nand_read(j->nand, p,
 				     0, 1 << j->nand->log2_page_size,
 				     j->page_buf, err) &&
+		    (hdr_has_magic(j->page_buf)) &&
 		    (hdr_get_epoch(j->page_buf) == j->epoch)) {
 			j->root = p - 1;
 			return 0;


### PR DESCRIPTION
If a power failure occured prior to resume, and the current epoch is
0xff, and the NAND driver uses a checksum which is valid for
unprogrammed pages, then find_root() may erroneously pick a blank page
instead of a valid checkpoint page, because it looks only for a matching
epoch byte. We need to look for the magic word as well to avoid this.

Issue pointed out by gtsee on github.com.